### PR TITLE
Use human-friendly strings instead of doing date calcs

### DIFF
--- a/src/components/Registration/TournamentDetails/Heading.js
+++ b/src/components/Registration/TournamentDetails/Heading.js
@@ -11,11 +11,11 @@ const Heading = ({tournament}) => {
    * @hack To get dates to seem like they're behaving. But they're actually not.
    * @todo Use a JS library for date/time handling that can properly distinguish dates from timestamps
    */
-  let datesString = '';
+  let datesString;
   const start = new Date(`${tournament.startDate}T12:00:00-04:00`);
-  if (tournament.startDate === tournament.endDate) {
+  if (tournament.startingDate === tournament.endingDate) {
     // it's one day
-    datesString = format(start, 'PPP');
+    datesString = tournament.startingDate;
   } else {
     const end = new Date(`${tournament.endDate}T12:00:00-04:00`);
     const startMonth = format(start, 'LLLL');

--- a/src/components/Registration/TournamentListing/TournamentCards.js
+++ b/src/components/Registration/TournamentListing/TournamentCards.js
@@ -1,4 +1,3 @@
-import {format} from "date-fns";
 import {Card, Col, Row} from "react-bootstrap";
 import TournamentLogo from "../TournamentLogo/TournamentLogo";
 
@@ -36,7 +35,7 @@ const TournamentCards = ({tournaments}) => (
                         {t.location}
                       </Card.Text>
                       <Card.Text>
-                        {format(new Date(t.startDate), 'PPP')}
+                        {t.startingDate}
                       </Card.Text>
                       {t.state === 'closed' && (
                         <Card.Text className={`fst-italic`}>


### PR DESCRIPTION
Because parsing date-only strings is still a mess, somehow.